### PR TITLE
luaPrinter: Change lua to improve compatibility

### DIFF
--- a/src/luaPrinter.ml
+++ b/src/luaPrinter.ml
@@ -205,7 +205,6 @@ end@\n") ()
           Format.fprintf f "
 function readcharline()
   local tab = {}
-  local i = 0
   for a in string.gmatch(io.read(\"*l\"), \".\") do
     table.insert(tab, string.byte(a))
   end
@@ -218,7 +217,7 @@ end@\n") ()
       (fun f () -> if need then Format.fprintf f "buffer =  \"\"@\n") ()
       (fun f () -> if need_readint then Format.fprintf f "function readint()
     if buffer == \"\" then buffer = io.read(\"*line\") end
-    local num, buffer0 = string.match(buffer, '^([\\-0-9]*)(.*)')
+    local num, buffer0 = string.match(buffer, '^([%%-0-9]*)(.*)')
     buffer = buffer0
     return tonumber(num)
 end@\n") ()


### PR DESCRIPTION
This PR consists of two changes:
 - Remove an unused variable, to close prologin/metalang#6
 - Change the way a lua pattern was made to increase compatibility. The
 previous pattern was only compatible with lua 5.1 while this new one is
 compatible with lua versions ranging from 5.1 to 5.3, including luajit
 (used at prologin).