### PR TITLE
Package metalang

### DIFF
--- a/src/libmetalang.ml
+++ b/src/libmetalang.ml
@@ -294,7 +294,11 @@ let remove_unknown_languages =
 let stdlib_file =
   try
     Sys.getenv "METALANG_STDLIB"
-  with Not_found -> "Stdlib/stdlib.metalang"
+  with Not_found ->
+    if Sys.file_exists "/usr/lib/metalang/stdlib.metalang" then
+      "/usr/lib/metalang/stdlib.metalang"
+    else
+      "Stdlib/stdlib.metalang"
 
 (** {2 Command Line Arguments} *)
 

--- a/tools/PKGBUILD
+++ b/tools/PKGBUILD
@@ -1,0 +1,33 @@
+# Maintainer: Kilian Guillaume "cafehaine" <kilian dot guillaume at gmail dot com>
+pkgname=metalang-git
+_realname=metalang
+pkgver=r1452.067b70d2
+pkgrel=1
+pkgdesc="Metalang compiler"
+arch=('x86_64' 'i686')
+url="https://github.com/prologin/metalang/"
+license=('BSD2')
+provides=('metalang')
+depends=()
+makedepends=('ocamlbuild' 'ocaml-findlib' 'ocaml-menhir')
+#TODO fixme
+source=("git+https://github.com/cafehaine/metalang/")
+md5sums=('SKIP')
+
+pkgver() {
+	cd "$srcdir/$_realname"
+	printf "r%s.%s" "$(git rev-list --count HEAD)" "$(git rev-parse --short HEAD)"
+}
+
+build() {
+	cd "$srcdir/$_realname"
+	make metalang
+}
+
+package() {
+	cd "$srcdir/$_realname"
+	install -Dm644 LICENCE "$pkgdir/usr/share/licenses/$_realname/LICENSE"
+	install -Dm755 metalang "$pkgdir/usr/bin/$_realname"
+	install -Dm644 Stdlib/stdlib.metalang "$pkgdir/usr/lib/$_realname/stdlib.metalang"
+}
+


### PR DESCRIPTION
these commits allow loading stdlib.metalang form /usr/lib/metalang/stdlib.metalang, and adds a PKGBUILD for easier setup on arch-based distros (such as the prologin's environments)

Please note: if you plan on merging this PR some modifications are required in the PKGBUILD so it uses prologin/metalang and not this fork