### PR TITLE
Prepare packaging

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,8 @@ lua	?=	lua
 java	?=	java
 python	?=	python3
 
+PREFIX := /usr/local
+
 TESTSNOTCOMPILEFILES := $(basename $(filter %.metalang, \
 	$(shell ls tests/not_compile/)))
 
@@ -391,6 +393,11 @@ js/test.js : libmetalang.cma
 js/meta.js : js/test.js
 	#js_of_ocaml --runtime-only js/runtime.js
 	cat js/header.js js/test.js > js/meta.js
+
+install :
+	install -Dm644 LICENCE "$(PREFIX)/share/licenses/metalang/LICENSE"
+	install -Dm755 metalang "$(PREFIX)/bin/metalang"
+	install -Dm644 Stdlib/stdlib.metalang "$(PREFIX)/lib/metalang/stdlib.metalang"
 
 .PHONY: clean
 clean :

--- a/src/libmetalang.ml
+++ b/src/libmetalang.ml
@@ -292,9 +292,14 @@ let remove_unknown_languages =
   in List.filter go
 
 let stdlib_file =
-  try
-    Sys.getenv "METALANG_STDLIB"
-  with Not_found -> "Stdlib/stdlib.metalang"
+  let cur_dir = (Filename.dirname Sys.executable_name) in
+    try
+      List.find Sys.file_exists [
+        (try Sys.getenv "METALANG_STDLIB" with Not_found -> "");
+        cur_dir ^ "/Stdlib/stdlib.metalang";
+        cur_dir ^ "/../lib/stdlib.metalang"
+      ]
+    with Not_found -> failwith "Cannot find stdlib.metalang"
 
 (** {2 Command Line Arguments} *)
 


### PR DESCRIPTION
Prepares metalang for packaging

- adds an install rule to the Makefile
- searches for stdlib.metalang using dirname $0